### PR TITLE
강윤식 / BOJ 5557, BOJ 14719, BOJ 1339, BOJ 2482, BOJ 17070 / 구현, DP, 그리디 / 1주차

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,6 @@
 
 - 1학년: [https://www.acmicpc.net/problem/5557](https://www.acmicpc.net/problem/5557)
 - 빗물: [https://www.acmicpc.net/problem/14719](https://www.acmicpc.net/problem/14719)
+- 단어수학: [https://www.acmicpc.net/problem/1339](https://www.acmicpc.net/problem/1339)
+- 색상환: [https://www.acmicpc.net/problem/2482](https://www.acmicpc.net/problem/2482)
+- 파이프 옮기기 1: [https://www.acmicpc.net/problem/17070](https://www.acmicpc.net/problem/17070)

--- a/src/algorithm/yunsik/week1/boj/q1339/Main.java
+++ b/src/algorithm/yunsik/week1/boj/q1339/Main.java
@@ -1,0 +1,34 @@
+package algorithm.yunsik.week1.boj.q1339;
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int n = Integer.parseInt(br.readLine());
+        int[][] values = new int[26][2];
+        for (int i = 0; i < 26; i++) {
+            values[i][0] = i;
+        }
+
+        char[] input;
+        for (int i = 0; i < n; i++) {
+            input = br.readLine().toCharArray();
+            int len = input.length;
+            for (int j = 0; j < len; j++) {
+                int charIndex = input[j] - 'A';
+                values[charIndex][1] += (int) Math.pow(10, len - 1 - j);
+            }
+        }
+
+        Arrays.sort(values, Comparator.comparingInt(i -> -i[1]));
+        int ans = 0;
+        for (int i = 0; i < 9; i++) {
+            ans += values[i][1] * (9 - i);
+        }
+        bw.write(ans + "\n");
+        bw.flush();
+    }
+}

--- a/src/algorithm/yunsik/week1/boj/q14719/Main.java
+++ b/src/algorithm/yunsik/week1/boj/q14719/Main.java
@@ -1,4 +1,39 @@
 package algorithm.yunsik.week1.boj.q14719;
 
+import java.io.*;
+import java.util.StringTokenizer;
+import java.util.stream.Stream;
+
 public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        st.nextToken();
+        int m = Integer.parseInt(st.nextToken());
+        int[] height = Stream.of(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+
+        int ans = 0;
+        int bound = height[0];
+        for (int i = 1; i < m; i++) {
+            if (height[i - 1] < height[i]) {
+                int cur = i - 1;
+                while (cur >= 0 && height[cur] < Math.min(bound, height[i])) {
+                    cur--;
+                }
+
+                if (cur != -1) {
+                    int temp = 0;
+                    for (int j = i - 1; j > cur; j--) {
+                        ans += Math.min(bound, height[i]) - Math.max(temp, height[j]);
+                        temp = Math.max(temp, height[j]);
+                    }
+                }
+                bound = Math.max(bound, height[i]);
+            }
+        }
+        bw.write(ans + "\n");
+        bw.flush();
+    }
 }

--- a/src/algorithm/yunsik/week1/boj/q17070/Main.java
+++ b/src/algorithm/yunsik/week1/boj/q17070/Main.java
@@ -1,0 +1,67 @@
+package algorithm.yunsik.week1.boj.q17070;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.stream.Stream;
+
+public class Main {
+    static int[][] board;
+    static int[][][] dp;
+    static final int[] tailDx = {0, -1, -1};
+    static final int[] tailDy = {-1, -1, 0};
+    static int n;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        n = Integer.parseInt(br.readLine());
+        board = new int[n][];
+        dp = new int[n][n][3];
+
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                Arrays.fill(dp[i][j], -1);
+            }
+        }
+        boolean block = false;
+        for (int i = 0; i < n; i++) {
+            board[i] = Stream.of(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+            if(board[0][i] == 1)
+                block = true;
+            dp[0][i][0] = block ? 0 : 1;
+        }
+        dp[0][0][0] = 0;
+
+        int ans = 0;
+        for (int i = 0; i < 3; i++) {
+            ans += findCaseCnt(n - 1, n - 1, i);
+        }
+        bw.write(ans + "\n");
+        bw.flush();
+    }
+
+    private static int findCaseCnt(int x, int y, int c) {
+        if (checkInvalidState(x, y, c)) return 0;
+        if (dp[x][y][c] != -1) return dp[x][y][c];
+
+        int result = findCaseCnt(x + tailDx[c], y + tailDy[c], 1);
+        if (c == 0) {
+            result += findCaseCnt(x, y - 1, c);
+        } else if (c == 1) {
+            result += findCaseCnt(x - 1, y - 1, 0) + findCaseCnt(x - 1, y - 1, 2);
+        } else {
+            result += findCaseCnt(x - 1, y, c);
+        }
+        return dp[x][y][c] = result;
+    }
+
+    private static boolean checkInvalidState(int x, int y, int c) {
+        if (outRange(x, y) || board[x][y] == 1) return true;
+        if (outRange(x + tailDx[c], y + tailDy[c]) || board[x+ tailDx[c]][y+ tailDy[c]] == 1) return true;
+        return (c == 1 && (board[x][y-1] == 1 || board[x-1][y] == 1));
+    }
+
+    private static boolean outRange(int x, int y) {
+        return x < 0 || y < 0 || x >= n || y >= n;
+    }
+}

--- a/src/algorithm/yunsik/week1/boj/q2482/Main.java
+++ b/src/algorithm/yunsik/week1/boj/q2482/Main.java
@@ -1,0 +1,33 @@
+package algorithm.yunsik.week1.boj.q2482;
+
+import java.io.*;
+import java.util.Arrays;
+
+public class Main {
+    static int[][] dp;
+    static final int mod = 1000000003;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int n = Integer.parseInt(br.readLine());
+        int k = Integer.parseInt(br.readLine());
+        dp = new int[n + 1][k + 1];
+        for (int i = 1; i <= n; i++) {
+            Arrays.fill(dp[i], -1);
+            dp[i][1] = i;
+        }
+
+        int ans;
+        if(k == 1) ans = n;
+        else ans = (getDP(n - 3, k - 1) + getDP(n - 1, k)) % mod;
+        bw.write(ans + "\n");
+        bw.flush();
+    }
+
+    private static int getDP(int n, int k) {
+        if (k > n / 2 + 1) return 0;
+        if (dp[n][k] != -1) return dp[n][k];
+        return dp[n][k] = (getDP(n - 2, k - 1) + getDP(n - 1, k)) % mod;
+    }
+}

--- a/src/algorithm/yunsik/week1/boj/q5557/Main.java
+++ b/src/algorithm/yunsik/week1/boj/q5557/Main.java
@@ -1,4 +1,28 @@
 package algorithm.yunsik.week1.boj.q5557;
 
+import java.io.*;
+import java.util.stream.Stream;
+
 public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        int N = Integer.parseInt(br.readLine());
+        int[] inputs = Stream.of(br.readLine().split(" ")).mapToInt(Integer::parseInt).toArray();
+        long[][] dp = new long[N - 1][21];
+
+        dp[0][inputs[0]] = 1L;
+        for (int i = 0; i < N - 2; i++) {
+            for (int j = 0; j <= 20; j++) {
+                if (dp[i][j] > 0) {
+                    if (j - inputs[i + 1] >= 0)
+                        dp[i + 1][j - inputs[i + 1]] += dp[i][j];
+                    if (j + inputs[i + 1] <= 20)
+                        dp[i + 1][j + inputs[i + 1]] += dp[i][j];
+                }
+            }
+        }
+        bw.write(dp[N - 2][inputs[N - 1]] + "\n");
+        bw.flush();
+    }
 }


### PR DESCRIPTION
## 문제 :mag:

[BOJ/5557번](https://www.acmicpc.net/problem/5557) 1학년

[BOJ/14719번](https://www.acmicpc.net/problem/14719) 빗물

[BOJ/1339번](https://www.acmicpc.net/problem/1339) 단어 수학

[BOJ/2482번](https://www.acmicpc.net/problem/2482) 색상환

[BOJ/17070번](https://www.acmicpc.net/problem/17070) 파이프 옮기기 1


---------------------------------------------------------------------------

## 히스토리 :memo:

### BOJ/5557: 1학년

> 1회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week1/boj/q5557/Main.java)
- 정수형 Long 범위
- 배열 인덱스 범위 주의

### BOJ/14719: 빗물

> 1회 : 오답 <br>
> 2회 : 오답 <br>
> 3회 : 오답 <br>
> 4회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week1/boj/q14719/Main.java)
- 1,2,3회 : 단순 반복문 구현 시도. 반례 존재.
- 현재까지 탐색했던 최고 높이 기록하여 해결.
- 두 번 중복해서 세어지는 구간을 해결하지 못햇었음.
- 중첩된 반복문에서도 최고 높이를 기록하여 반례 해결.

### BOJ/1339: 단어수학

> 1회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week1/boj/q1339/Main.java)
- 알파벳의 자릿수에 해당하는 가치를 저장하여 해결.
- ABBA 문자열의 경우, A는 1001의 가치, B는 110의 가치를 나타냄.
- 가치가 높은 순서대로 9~1의 수를 곱해가며 합을 계산.

### BOJ/2482: 색상환

> 1회 : 오답 <br>
> 2회 : 시간초과 <br>
> 3회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week1/boj/q2482/Main.java)
- 1회 : 1개의 특정 색을 선택하는 경우와 선택하지 않는 경우의 수를 같다고 생각하여 오답.
- 2회 : 메서드 1번당 n번 재귀 호출이 발생하므로, 최악의 경우 O(n^3) 호출되어 시간초과 발생.
- 3회 : 점화식 + DP로 구현. 특정 색에 대해 선택/미선택으로 나누어 해결.

### BOJ/17070: 파이프 옮기기 1

> 1회 : 오답 <br>
> 2회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week1/boj/q17070/Main.java)
- 1회 : dp 배열 초기화 문제. 첫째 줄에 벽이 있을 때마다 초기화가 아닌, 한번 벽이 있으면 이후도 경우의 수가 0이 되어야 함.
- 2회 : [행][열][3방향] dp 배열로 해결.

<br>

---------------------------------------------------------------------------

## 하고 싶은 말(optional)

### BOJ/5557: 1학년

DP를 2차원 배열로 구현하는 문제였습니다.

(1 <= K <= N-2) 인 K에 대해 2차원 배열(N-1, 21)을 순차적으로 순회하며 +- 값을 저장하며 구현 했습니다.


### BOJ/14719: 빗물


완전 탐색 O(n^3)으로 해결하거나 Stack을 사용하여 해결할 수 있다고도 생각합니다.

저는 단순 구현으로 해결했고 아이디어는 아래와 같습니다.


> 1. 가장 왼쪽의 높이부터 순차적으로 탐색한다. (index는 0이 아닌 1부터)
> 2. 현재 탐색 중인 높이(height[i])가 바로 좌측의 높이(height[i-1])보다 크다면. 즉, 높이가 해당 인덱스(i)에서 증가한다면
> 3. 해당 인덱스의 좌측을 탐색하며 좌측의 높이가 같아지거나 커질 때 까지 인덱스인 (cur) 값을 (i-1)부터 줄여나갑니다.
> 4. cur 값이 -1이 아니라면 좌측을 찾은 것이고, 총 높이 값을 업데이트 합니다.

<br>

#### 추가 조건

- [3,0,1,4] 인 케이스에서 4의 높이에서 좌측으로 탐색하는 경우, 3의 높이로 계산하여 총 값을 업데이트 해야 합니다.

    + bound 변수로 현재까지 탐색했던 최고의 높이를 기록했습니다. (height[i]는 bound 보다 작거나 같아야 합니다.)

- [4,3,1,2,5] 인 케이스에서 높이가 1인 부분을 두 번 세게 됩니다.

    + 마찬가지로 중첩된 반복문에서도 temp 값으로 최고 높이를 저장하여 i=4 에선 [4,3,2,2,5] 으로 계산하도록 합니다.
    + (cur != -1 일때 수행하는 반복문)

### BOJ/1339: 단어 수학

1~9까지의 수로 대체하는 경우 자릿수에 따라 계산된 가치에 곱하는 방식으로 구현했습니다.

브루트포스로 구현해도 될 것 같습니다.

### BOJ/2482: 색상환

점화식 + DP로 구현했습니다.

원판이 아닌 일렬로 생각하고, F(n,k)를 n개의 색 중에 이웃하지 않는 k개의 색을 고른 경우의 수라고 할 때,
첫 색을 선택하는 경우 F(n-2,k-1)이 되고 선택하지 않는 경우는 F(n-1,k)이 됩니다.
따라서 `F(n,k) = F(n-2,k-1) + F(n-1,k)` 값을 DP로 계산하도록 하며

다시 원판의 관점에서, 첫 색을 선택하는 경우의 수는 {선택한 색 + 좌 + 우} 총 3개의 색을 사용하지 못하게 되므로 F(n-3,k-1)이고,
선택하지 않는 경우는 F(n-1,k) 이므로 `F(n-3,k-1) + F(n-1,k)`을 출력하도록 구현했습니다.

### BOJ/17070: 파이프 옮기기 1

우측 하단의 파이프 위치와 방향을 인덱스로 하는 3차원 배열 DP로 구현했습니다.

> [?][?][0] 은 가로 방향 파이프의 경우의 수. <br>
> [?][?][1] 은 대각선 방향 파이프의 경우의 수. <br>
> [?][?][2] 은 세로 방향 파이프의 경우의 수. <br>

범위를 벗어나거나 벽에 막혀서 가능하지 않은 파이프의 위치를 재귀로 호출하면 0을 리턴합니다.

tailDx, tailDy로 파이프의 다른 한쪽 위치를 나타내는 벡터로 사용합니다.

모든 방향의 파이프는 꼬리 부분이 대각선에서 도달할 수 있으므로 `findCaseCnt(x + tailDx[c], y + tailDy[c], 1)`
로 초기화하고 나머지는 분기처리 후 DP를 사용한 재귀호출 했습니다.

