### PR TITLE
강윤식 / BOJ 1913, BOJ 2578, BOJ 4396, BOJ 12933, BOJ 14467 / 구현 / 2주차

### DIFF
--- a/src/algorithm/yunsik/week2/boj/q12933/Main.java
+++ b/src/algorithm/yunsik/week2/boj/q12933/Main.java
@@ -1,0 +1,45 @@
+package algorithm.yunsik.week2.boj.q12933;
+
+import java.io.*;
+import java.util.ArrayDeque;
+
+public class Main {
+    static final char[] seq = {'q', 'u', 'a', 'c', 'k'};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        ArrayDeque<Character> deque = new ArrayDeque<>();
+        for (char c : br.readLine().toCharArray()) {
+            deque.addLast(c);
+        }
+
+        int size = deque.size();
+        int ans = 0, prev;
+        do {
+            int cnt = 0;
+            int idx = 0;
+            prev = size;
+            while (size-- > 0) {
+                Character first = deque.removeFirst();
+                if (first == seq[idx]) {
+                    if (++idx == 5) {
+                        cnt++;
+                        idx %= 5;
+                    }
+                } else {
+                    deque.addLast(first);
+                }
+            }
+            for (int i = 0; i < idx; i++) {
+                deque.addLast(seq[i]);
+            }
+            if (cnt > 0) ans++;
+            size = deque.size();
+        } while (prev != size);
+
+        if (ans == 0 || size != 0) ans = -1;
+        bw.write(String.valueOf(ans));
+        bw.flush();
+    }
+}

--- a/src/algorithm/yunsik/week2/boj/q14467/Main.java
+++ b/src/algorithm/yunsik/week2/boj/q14467/Main.java
@@ -1,0 +1,31 @@
+package algorithm.yunsik.week2.boj.q14467;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] cowPosition = new int[11];
+        int a, b, ans = 0;
+        Arrays.fill(cowPosition, -1);
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            a = Integer.parseInt(st.nextToken());
+            b = Integer.parseInt(st.nextToken());
+            if (cowPosition[a] == -1) {
+                cowPosition[a] = b;
+            } else if (cowPosition[a] != b) {
+                cowPosition[a] = b;
+                ans++;
+            }
+        }
+        bw.write(ans + "\n");
+        bw.flush();
+    }
+}

--- a/src/algorithm/yunsik/week2/boj/q1913/Main.java
+++ b/src/algorithm/yunsik/week2/boj/q1913/Main.java
@@ -1,0 +1,48 @@
+package algorithm.yunsik.week2.boj.q1913;
+
+import java.io.*;
+
+public class Main {
+    static final int[] dx = {1, 0, -1, 0};
+    static final int[] dy = {0, 1, 0, -1};
+    static int[][] board;
+    static int N;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder ans = new StringBuilder();
+        int curX = 0, curY = 0, dir = 0, ansX = -1, ansY = -1;
+        N = Integer.parseInt(br.readLine());
+        int P = Integer.parseInt(br.readLine());
+
+        board = new int[N][N];
+        int cur = N * N;
+        while (cur > 0) {
+            board[curX][curY] = cur;
+            if (cur-- == P) {
+                ansX = curX + 1;
+                ansY = curY + 1;
+            }
+            if (outRange(curX + dx[dir], curY + dy[dir]) || board[curX + dx[dir]][curY + dy[dir]] != 0) {
+                dir = (dir + 1) % 4;
+            }
+            curX += dx[dir];
+            curY += dy[dir];
+        }
+
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                ans.append(board[i][j]).append(" ");
+            }
+            ans.append("\n");
+        }
+        ans.append(ansX).append(" ").append(ansY);
+        bw.write(ans.toString());
+        bw.flush();
+    }
+
+    private static boolean outRange(int x, int y) {
+        return x < 0 || y < 0 || x >= N || y >= N;
+    }
+}

--- a/src/algorithm/yunsik/week2/boj/q2578/Main.java
+++ b/src/algorithm/yunsik/week2/boj/q2578/Main.java
@@ -1,0 +1,46 @@
+package algorithm.yunsik.week2.boj.q2578;
+
+import java.io.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int[] seq = new int[25];
+    static int[] row = new int[]{5, 5, 5, 5, 5};
+    static int[] col = new int[]{5, 5, 5, 5, 5};
+    static int[] dia = new int[]{5, 5};
+    static Map<Integer, int[]> map = new HashMap<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        for (int i = 0; i < 5; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            for (int j = 0; j < 5; j++) {
+                map.put(Integer.parseInt(st.nextToken()), new int[]{i, j});
+            }
+        }
+        for (int i = 0; i < 5; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            for (int j = 0; j < 5; j++) {
+                seq[i * 5 + j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        int cur = 0;
+        int bingo = 0;
+        while (cur < 25) {
+            int[] location = map.get(seq[cur]);
+            if (--row[location[0]] == 0 && ++bingo == 3) break;
+            if (--col[location[1]] == 0 && ++bingo == 3) break;
+            if (location[0] == location[1] && dia[0] == 0 && ++bingo == 3) break;
+            if (location[0] + location[1] == 4 && --dia[1] == 0 && ++bingo == 3) break;
+            cur++;
+        }
+        bw.write(String.valueOf(cur + 1));
+        bw.flush();
+    }
+}

--- a/src/algorithm/yunsik/week2/boj/q4396/Main.java
+++ b/src/algorithm/yunsik/week2/boj/q4396/Main.java
@@ -1,0 +1,70 @@
+package algorithm.yunsik.week2.boj.q4396;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class Main {
+    static char[][] board, ans;
+    static final int[] dx = {0, 0, 1, 1, 1, -1, -1, -1};
+    static final int[] dy = {1, -1, 1, 0, -1, 1, 0, -1};
+    static int n;
+    static List<int[]> ePos = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+        n = Integer.parseInt(br.readLine());
+        board = new char[n][];
+        ans = new char[n][n];
+        for (int i = 0; i < n; i++) {
+            Arrays.fill(ans[i], '.');
+            board[i] = br.readLine().toCharArray();
+            for (int j = 0; j < n; j++) {
+                if (board[i][j] == '*') {
+                    ePos.add(new int[]{i, j});
+                }
+            }
+        }
+
+        String input;
+        int cnt;
+        boolean exp = false;
+        for (int i = 0; i < n; i++) {
+            input = br.readLine();
+            for (int j = 0; j < n; j++) {
+                if (input.charAt(j) == 'x') {
+                    if (board[i][j] == '*') {
+                        exp = true;
+                    } else {
+                        cnt = 0;
+                        for (int k = 0; k < 8; k++) {
+                            if (inRange(i + dx[k], j + dy[k]) && board[i + dx[k]][j + dy[k]] == '*') {
+                                cnt++;
+                            }
+                        }
+                        ans[i][j] = (char) (cnt + '0');
+                    }
+                }
+            }
+        }
+
+        if(exp){
+            for (int[] pos : ePos) {
+                ans[pos[0]][pos[1]] = '*';
+            }
+        }
+
+        for (int i = 0; i < n; i++) {
+            sb.append(ans[i]).append("\n");
+        }
+        bw.write(sb.toString());
+        bw.flush();
+    }
+
+    static boolean inRange(int x, int y) {
+        return x >= 0 && y >= 0 && x < n && y < n;
+    }
+}


### PR DESCRIPTION
## 문제 :mag:

[BOJ/1913번](https://www.acmicpc.net/problem/1913) 달팽이

[BOJ/2578번](https://www.acmicpc.net/problem/2578) 빙고

[BOJ/4396번](https://www.acmicpc.net/problem/4396) 지뢰 찾기

[BOJ/12933번](https://www.acmicpc.net/problem/12933) 오리

[BOJ/14467번](https://www.acmicpc.net/problem/14467) 소가 길을 건넌 이유 1


---------------------------------------------------------------------------

## 히스토리 :memo:

### BOJ/1913: 달팽이

> 1회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week2/boj/q1913/Main.java)
- 반대로 생각하여 N*N 만큼 순회.
- 다음 예상 경로가 배열의 크기를 벗어나거나 이미 쓰여진(0이 아닌) 곳이라면, 방향을 변경

### BOJ/2578: 빙고

> 1회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week2/boj/q2578/Main.java)
- 빙고는 가로 5개, 세로 5개, 대각선 2개가 존재.
- 위의 총 12개의 경우에 대해 빙고까지 남은 개수를 5개로 초기화.

### BOJ/4396: 지뢰 찾기

> 1회 : 오답 <br>
> 2회 : 오답 <br>
> 3회 : 오답 <br>
> 4회 : 오답 <br>
> 5회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week2/boj/q4396/Main.java)
- 문제를 잘 읽고 풀 것!
- 지뢰가 있는 칸을 열었다면 모든 지뢰를 표시해야 했지만 그러지 않아서 오답.
- 모든 지뢰를 표시했지만 남은 숫자들을 모두 출력하지 않고 온점으로 출력하여 오답.

### BOJ/12933: 오리

> 1회 : 오답 <br>
> 2회 : 오답 <br>
> 3회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week2/boj/q12933/Main.java)
- 1회 : 'q', 'u', 'a', 'c', 'k' 한 사이클을 완수하지 못한 경우 초기화하지 않아 오답.
- 2회 : 정상적이지 않은 문자열에 대해 -1 을 출력하지 않아 오답.
- 3회 : ArrayDeque 을 사용하여 순차적으로 조회하며, 사이클을 탐색하고 제거.

### BOJ/14467: 소가 길을 건너간 이유 1

> 1회 : 오답 <br>
> 2회 : [성공](https://github.com/kangyunsik/algorithm-study/blob/main/src/algorithm/yunsik/week2/boj/q14467/Main.java)
- 1회 : 소의 위치가 바뀌었을 경우 업데이트를 진행하지 않아 오답.
- 2회 : 소의 위치를 -1로 초기화하고, 1이나 0이 들어오는 경우 초기 업데이트 및 다른 경우 값을 증가시키도록 구현.

<br>

---------------------------------------------------------------------------

## 하고 싶은 말(optional)

### BOJ/1913: 달팽이

주어진 문제대로 가운데부터 숫자를 증가시키며 방향을 변환시키는 것은 어렵다고 생각됐습니다.

반대로 생각해서 (0,0) 부터 시작하여 남, 동, 북, 서 방향으로 회전하도록 구현했습니다.

주어진 자연수가 홀수이기 때문에 가능했습니다.

### BOJ/2578: 빙고

빙고를 만들 수 있는 경우는 가로 5개, 세로 5개, 대각선 2개입니다.

12개의 배열을 만들고 5로 초기화하여 입력된 수에 해당하는 행/열 혹은 조건이 맞는다면 대각선의 값을 감소시키도록 구현했습니다.

들어오는 값에 해당하는 인덱스를 찾기 위해 Map 을 사용하였고, 총 빙고의 수를 기록하는 cnt 값이 3이 되면 반복문을 탈출하고 출력하도록 했습니다.


### BOJ/4396: 지뢰 찾기

2차원 배열의 모든 경우에 대해 8방향을 탐색하고 지뢰의 개수를 기록하여 숫자로 출력하도록 구현했습니다.

지뢰를 열었다면, boolean exp 를 true 로 설정해두고, 저장되어 있던 모든 지뢰의 위치에 '*'을 출력하도록 구현.

### BOJ/12933: 오리

ArrayDeque 을 이용하여 덱의 크기를 기록하고, 순차적으로 조회하며 사이클을 제거해 나가도록 구현했습니다.

사이클을 완수하지 못한 경우, 다시 중단된 사이클의 개수(idx)인 i < idx 만큼 덱의 마지막에 다시 추가.

사이클을 한번이라도 완수했다면, ans 값을 증가시키고, 변화가 없을 때 까지 반복.

size 가 0이면, 정상적이지 않은 문자열로 판단하고, ans 가 0이면 사이클이 하나도 없는 경우이므로 -1을 출력.

### BOJ/14467: 소가 길을 건너간 이유 1

소들이 발견되지 않은 상태는 -1, 왼쪽은 0, 오른쪽은 1로 두고, -1 상태에서 값이 들어오면 해당 값으로 업데이트 하도록 구현했습니다.

업데이트가 된 소의 위치값이 다른 값으로 들어오면, ans 값을 증가시키고 해당 위치로 변경.

증가된 ans 값을 출력하도록 구현.