### PR TITLE
조민제 / BOJ 2606, BOJ 9663, BOJ 17829, BOJ 20115, BOJ 20365 / 그래프, 백트래킹, 분할 정복, 그리디 / 3주차

### DIFF
--- a/src/algorithm/minje/week3/boj/q17829/Main.java
+++ b/src/algorithm/minje/week3/boj/q17829/Main.java
@@ -1,0 +1,68 @@
+package algorithm.minje.week3.boj.q17829;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    static int N, matrix[][];
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+
+        N = Integer.parseInt(br.readLine());
+        matrix = new int[N][N];
+
+        for (int i = 0; i < N; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+            for (int j = 0; j < N; j++) {
+                matrix[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        polling(2);
+
+        sb.append(matrix[0][0]);
+
+        bw.write(sb.toString());
+        bw.flush();
+    }
+
+    static void rtSndBiggest(int r, int c,int size) {
+
+        List<Integer> tmp = new ArrayList<>();
+
+        for (int i = r; i < r+size; i+=size/2) {
+            for (int j = c; j < c+size; j+=size/2) {
+                tmp.add(matrix[i][j]);
+            }
+        }
+        tmp.sort((a,b)->b-a);
+
+        int sndBiggest = tmp.get(1);
+        for (int i = r; i < r+size; i+=size/2) {
+            for (int j = c; j < c+size; j+=size/2) {
+                matrix[i][j]= sndBiggest;
+            }
+        }
+    }
+
+    static void polling(int size){
+
+        for (int i = 0; i < N; i+=size) {
+            for (int j = 0; j < N; j+=size) {
+                rtSndBiggest(i,j,size);
+            }
+        }
+
+        if(size == N) return;
+        polling(size*2);
+    }
+}

--- a/src/algorithm/minje/week3/boj/q20115/Main.java
+++ b/src/algorithm/minje/week3/boj/q20115/Main.java
@@ -1,0 +1,43 @@
+package algorithm.minje.week3.boj.q20115;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int max = Integer.MIN_VALUE;
+    static int maxIdx = -1;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+
+        int N = Integer.parseInt(br.readLine());
+
+        int[] quantList = new int[N];
+
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        for (int i = 0; i < N; i++) {
+            int input = Integer.parseInt(st.nextToken());
+            if (max < input) {
+                max = input;
+                maxIdx = i;
+            }
+            quantList[i] = input;
+        }
+
+        float ans = quantList[maxIdx];
+        for (int i = 0; i < quantList.length; i++) {
+            if (i == maxIdx) continue;
+            ans += quantList[i] / 2.0;
+        }
+
+        sb.append(ans);
+        bw.write(sb.toString());
+        bw.flush();
+    }
+}

--- a/src/algorithm/minje/week3/boj/q20365/Main.java
+++ b/src/algorithm/minje/week3/boj/q20365/Main.java
@@ -1,0 +1,45 @@
+package algorithm.minje.week3.boj.q20365;
+/*
+메모리 : 19580KB
+시간 : 152ms
+ */
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+    static int paintCnt = 1;
+    static char[] colorArr;
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+
+        int N = Integer.parseInt(br.readLine());
+        colorArr = new char[N];
+        colorArr = br.readLine().toCharArray();
+
+        char fstColor = colorArr[0];
+        for (int i = 0; i < N; i++) {
+            if(colorArr[i] != fstColor){
+                paintCnt++;
+
+                while(i<N-1){
+                    if(colorArr[i] == colorArr[i+1]){
+                        i++;
+                    }
+                    else{
+                        break;
+                    }
+                }
+            }
+        }
+
+        sb.append(paintCnt);
+        bw.write(sb.toString());
+        bw.flush();
+    }
+
+}

--- a/src/algorithm/minje/week3/boj/q2606/Main.java
+++ b/src/algorithm/minje/week3/boj/q2606/Main.java
@@ -1,0 +1,72 @@
+package algorithm.minje.week3.boj.q2606;
+
+/*
+메모리 : 11828KB
+시간 : 76ms
+ */
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+class Node{
+    int vertex;
+    Node link;
+
+    Node(int vertex,Node link){
+        this.vertex = vertex;
+        this.link = link;
+    }
+}
+
+public class Main {
+    static int N,infectedN;
+    static Node[] adjList;
+    static boolean[] visited;
+
+    public static void main(String[] args) throws Exception{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+
+        N = Integer.parseInt(br.readLine());
+        int E = Integer.parseInt(br.readLine());
+        adjList = new Node[N+1];
+        visited = new boolean[N+1];
+
+        for (int i = 0; i < E; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine()," ");
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            adjList[from] = new Node(to,adjList[from]);
+            adjList[to] = new Node(from,adjList[to]);
+        }
+
+        bfs(1);
+
+        sb.append(infectedN-1);
+        bw.write(sb.toString());
+        bw.flush();
+    }
+
+    static void bfs(int start){
+        Queue<Integer> q = new LinkedList<Integer>();
+        q.offer(start);
+
+        while(!q.isEmpty()){
+            int cur = q.poll();
+            for (Node from = adjList[cur]; from != null; from=from.link) {
+                if(!visited[from.vertex]){
+                    visited[from.vertex] = true;
+                    infectedN++;
+                    q.offer(from.vertex);
+                }
+            }
+        }
+    }
+}

--- a/src/algorithm/minje/week3/boj/q9663/Main.java
+++ b/src/algorithm/minje/week3/boj/q9663/Main.java
@@ -1,0 +1,44 @@
+package algorithm.minje.week3.boj.q9663;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+public class Main {
+
+    static int N, locationList[];
+    static int ans=0;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+
+        N = Integer.parseInt(br.readLine());
+        locationList = new int[N];
+
+        dfs(0);
+
+        sb.append(ans);
+        bw.write(sb.toString());
+        bw.flush();
+    }
+
+    static void dfs(int count) {
+        if(count == N-1){
+            ans++;
+            return;
+        }
+
+        Loop: for (int newLoc = 0; newLoc < N; newLoc++) {
+            for (int i = 0; i < count; i++) {
+                if (locationList[i] == newLoc || Math.abs(i - count) == Math.abs(locationList[i] - newLoc)) {
+                    continue Loop;
+                }
+            }
+            locationList[count] = newLoc;
+            dfs(count + 1);
+            //놔도 되는곳이면
+        }
+    }
+}

--- a/src/algorithm/minje/week3/boj/q9663/Main.java
+++ b/src/algorithm/minje/week3/boj/q9663/Main.java
@@ -1,5 +1,9 @@
 package algorithm.minje.week3.boj.q9663;
 
+/*
+메모리 : 12336KB
+시간 : 6220ms
+ */
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.InputStreamReader;
@@ -25,7 +29,7 @@ public class Main {
     }
 
     static void dfs(int count) {
-        if(count == N-1){
+        if(count == N){
             ans++;
             return;
         }

--- a/src/algorithm/minje/week4/boj/Q11559/Main_11559_Puyo_Puyo_조민제.java
+++ b/src/algorithm/minje/week4/boj/Q11559/Main_11559_Puyo_Puyo_조민제.java
@@ -1,0 +1,104 @@
+package algorithm.minje.week4.boj.Q11559;
+/*
+메모리 : 11864KB
+시간 : 88ms
+ */
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.*;
+
+public class Main_11559_Puyo_Puyo_조민제 {
+    static final int R = 12, C = 6, dr[] = {1, -1, 0, 0}, dc[] = {0, 0, -1, 1};
+    static char[][] map = new char[R][C];
+    static boolean[][] visited = new boolean[R][C];
+    static int comb;    // 뿌요 연쇄값
+    static List<int[]> trashBin = new ArrayList<>();    //뿌요면 삭제할 쓰레기통
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+
+        for (int r = 0; r < 12; r++) {
+            map[r] = br.readLine().toCharArray();
+        }
+
+        while (true) {
+            boolean isPuyo = false;
+            for (int r = 0; r < R; r++) {
+                for (int c = 0; c < C; c++) {
+                    if (map[r][c] != '.' && checkPuyo(r, c)) {
+                        isPuyo = true;
+                        removeCells();
+                    }
+                }
+            }
+            if (isPuyo) {
+                comb++;
+                actGravity();
+                visited = new boolean[R][C];
+            }
+            if (!isPuyo) break;
+        }
+
+
+        sb.append(comb);
+        bw.write(sb.toString());
+        bw.flush();
+    }
+
+    static boolean checkPuyo(int r, int c) {
+        trashBin.clear();
+        Queue<int[]> q = new LinkedList<>();
+        int count = 1;
+        visited[r][c] = true;
+
+        q.offer(new int[]{r, c});
+        trashBin.add(new int[]{r, c});
+
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            for (int d = 0; d < 4; d++) {
+                int nr = cur[0] + dr[d];
+                int nc = cur[1] + dc[d];
+                if (isValidRange(nr, nc) && !visited[nr][nc] && map[nr][nc] == map[r][c]) {
+                    count++;
+                    visited[nr][nc] = true;
+                    q.offer(new int[]{nr, nc});
+                    trashBin.add(new int[]{nr, nc});
+                }
+            }
+        }
+        return count >= 4;
+    }
+
+    static void removeCells() {
+        for (int[] cells : trashBin) {
+            map[cells[0]][cells[1]] = '.';
+        }
+    }
+
+    static void actGravity() {
+        Queue<Character> colors;
+        for (int c = 0; c < C; c++) {
+            colors = new LinkedList<>();
+
+            for (int r = R - 1; r >= 0; r--) {
+                if (map[r][c] != '.') colors.offer(map[r][c]);
+            }
+            for (int r = R - 1; r >= 0; r--) {
+                if (colors.isEmpty()) {
+                    map[r][c] = '.';
+                    continue;  // for reduce depth
+                }
+                map[r][c] = colors.poll();
+            }
+        }
+    }
+
+    static boolean isValidRange(int nr, int nc) {
+        return nr >= 0 && nc >= 0 && nr < R && nc < C;
+    }
+}

--- a/src/algorithm/minje/week4/boj/Q1261/Main_1261_알고스팟_조민제.java
+++ b/src/algorithm/minje/week4/boj/Q1261/Main_1261_알고스팟_조민제.java
@@ -1,0 +1,82 @@
+package algorithm.minje.week4.boj.Q1261;
+/*
+메모리 : 12460KB
+시간 : 112ms
+ */
+
+import javax.swing.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.HashMap;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+class Path implements Comparable<Path> {
+    int r;
+    int c;
+    int crashedWallCnt;
+
+    public Path(int r, int c, int crashedWallCnt) {
+        this.r = r;
+        this.c = c;
+        this.crashedWallCnt = crashedWallCnt;
+    }
+
+    @Override
+    public int compareTo(Path o) {
+        return this.crashedWallCnt - o.crashedWallCnt;
+    }
+}
+
+public class Main_1261_알고스팟_조민제 {
+    //상하좌우
+    static int N, M, dr[] = {1, -1, 0, 0}, dc[] = {0, 0, -1, 1};
+    static char[][] map;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+
+        M = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+        map = new char[N][M];
+
+        for (int r = 0; r < N; r++) {
+            map[r] = br.readLine().toCharArray();
+        }
+
+        sb.append(bfs(new boolean[N][M]));
+        bw.write(sb.toString());
+        bw.flush();
+    }
+
+    static int bfs(boolean[][] visited) {
+        PriorityQueue<Path> q = new PriorityQueue<>();
+        visited[0][0] = true;
+        q.offer(new Path(0, 0, 0));
+
+        while (!q.isEmpty()) {
+            Path cur = q.poll();
+            if (cur.r == N - 1 && cur.c == M - 1) return cur.crashedWallCnt;
+            for (int d = 0; d < 4; d++) {
+                int nr = cur.r + dr[d];
+                int nc = cur.c + dc[d];
+                int wallCnt = cur.crashedWallCnt;
+                if (isValidRange(nr, nc) && !visited[nr][nc]) {
+                    visited[nr][nc] = true;
+                    if (map[nr][nc] == '1') wallCnt++;
+                    q.offer(new Path(nr, nc, wallCnt));
+                }
+            }
+        }
+        return -1;
+    }
+
+    static boolean isValidRange(int nr, int nc) {
+        return nr >= 0 && nc >= 0 && nr < N && nc < M;
+    }
+}

--- a/src/algorithm/minje/week4/boj/Q16202/Main.java
+++ b/src/algorithm/minje/week4/boj/Q16202/Main.java
@@ -1,0 +1,110 @@
+package algorithm.minje.week4.boj.Q16202;
+/*
+
+ */
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+class Edge implements Comparable<Edge> {
+    int dest;
+    int weight;
+
+    public Edge(int dest, int weight) {
+        this.dest = dest;
+        this.weight = weight;
+    }
+
+    @Override
+    public int compareTo(Edge o) {
+        return this.weight - o.weight;
+    }
+}
+
+public class Main {
+    static int DEFAULT_STARTING = 1;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringBuilder sb = new StringBuilder();
+
+        StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int K = Integer.parseInt(st.nextToken());
+
+        PriorityQueue<Edge>[] adjList = new PriorityQueue[N + 1];
+
+        for (int i = 0; i < N + 1; i++) {
+            adjList[i] = new PriorityQueue<>();
+        }
+
+        int weight = 0;
+        for (int i = 0; i < M; i++) {
+            StringTokenizer st1 = new StringTokenizer(br.readLine(), " ");
+            int from = Integer.parseInt(st1.nextToken());
+            int to = Integer.parseInt(st1.nextToken());
+            weight++;
+
+            Edge newE = new Edge(to, weight);
+            adjList[from].add(newE);
+            adjList[to].add(new Edge(from, weight));
+        }
+
+
+        for (int turn = 0; turn < K; turn++) {
+            PriorityQueue<Edge> pq = new PriorityQueue<>();
+            boolean[] visited = new boolean[N + 1];
+            int cost = 0;
+            for (Edge edge : adjList[DEFAULT_STARTING]) {
+                pq.offer(edge);
+            }
+            visited[DEFAULT_STARTING] = true;
+
+            while (!pq.isEmpty()) {
+                Edge cur = pq.poll();
+                if (!visited[cur.dest]) {
+                    cost += cur.weight;
+                    visited[cur.dest] = true;
+                    for (Edge edge : adjList[cur.dest]) {
+                        pq.offer(edge);
+                    }
+                }
+            }
+
+            for (int i = 1; i <= N; i++) {
+                if (!visited[i]) cost = 0;
+            }
+            sb.append(cost + " ");
+
+            // ----------------poll minimum edge
+            int min = Integer.MAX_VALUE;
+            List<Integer> minList = new ArrayList<>();
+            for (int i = 1; i <= N; i++) {
+                if (!adjList[i].isEmpty()) {
+                    int cand = adjList[i].peek().weight;
+                    if (min > cand) {
+                        min = cand;
+                        minList.clear();
+                    }
+                    if (min == cand) {
+                        minList.add(i);
+                    }
+                }
+            }
+            for (Integer integer : minList) {
+
+                adjList[integer].poll();
+            }
+        }
+
+        bw.write(sb.toString());
+        bw.flush();
+    }
+}

--- a/src/algorithm/minje/week4/boj/Q1701/Main_1701_Cubeditor_조민제.java
+++ b/src/algorithm/minje/week4/boj/Q1701/Main_1701_Cubeditor_조민제.java
@@ -1,0 +1,35 @@
+package algorithm.minje.week4.boj.Q1701;
+/*
+메모리 : 110276KB
+시간 : 296ms
+ */
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class Main_1701_Cubeditor_조민제 {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        char[] str = br.readLine().toCharArray();
+
+        int[] pi = new int[str.length];
+        pi[0] = 0;
+        int max = 0;
+
+        for (int k = 0; k < str.length; k++) {
+            pi = new int[str.length];
+            pi[0] = 0;
+            for (int i = 1, j = 0; i < str.length-k; i++) {
+                while (j > 0 && str[i+k] != str[j+k]) j = pi[j - 1];
+                if (str[i+k] == str[j+k]) {
+                    pi[i] = ++j;
+                }
+            }
+            for (int i : pi) {
+                max = Math.max(i, max);
+            }
+        }
+
+        System.out.println(max);
+    }
+}

--- a/src/algorithm/minje/week4/boj/Q1958/Main_1958_LCS_3_조민제.java
+++ b/src/algorithm/minje/week4/boj/Q1958/Main_1958_LCS_3_조민제.java
@@ -1,0 +1,44 @@
+package algorithm.minje.week4.boj.Q1958;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Main_1958_LCS_3_조민제 {
+
+    static int longest=0;
+    static char[] LCS;
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        char[][] stringList = new char[3][];
+        List<Character> fstSndLCS = new ArrayList<>(); //중간삽입 없으니 ArrayList
+
+        for (int i = 0; i < 3; i++) {
+            stringList[i] = br.readLine().toCharArray();
+        }
+
+        int comCnt = 0;
+        int f = 0;
+        int s = 0;
+        for (int i = 0; i < stringList[0].length; i++) {
+            f = i;
+            while (stringList[0][f] == stringList[1][s]) {
+                fstSndLCS.add(stringList[0][f]);
+                comCnt++;
+                f++;
+                s++;
+            }
+            s=0;
+            if(longest < comCnt){
+                longest = comCnt;
+                LCS = new char[longest];
+                for (int chI = 0; chI<longest; chI++) {
+                    LCS[chI] = fstSndLCS.get(chI);
+                }
+            }
+        }
+
+
+    }
+}

--- a/src/algorithm/minje/week4/boj/Q1958/Main_1958_LCS_3_조민제.java
+++ b/src/algorithm/minje/week4/boj/Q1958/Main_1958_LCS_3_조민제.java
@@ -1,44 +1,39 @@
 package algorithm.minje.week4.boj.Q1958;
-
+/*
+메모리 : 17176KB
+시간 : 124ms
+ */
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.List;
 
 public class Main_1958_LCS_3_조민제 {
 
-    static int longest=0;
-    static char[] LCS;
     public static void main(String[] args) throws Exception {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         char[][] stringList = new char[3][];
-        List<Character> fstSndLCS = new ArrayList<>(); //중간삽입 없으니 ArrayList
 
         for (int i = 0; i < 3; i++) {
             stringList[i] = br.readLine().toCharArray();
         }
+        int F = stringList[0].length;
+        int S = stringList[1].length;
+        int T = stringList[2].length;
 
-        int comCnt = 0;
-        int f = 0;
-        int s = 0;
-        for (int i = 0; i < stringList[0].length; i++) {
-            f = i;
-            while (stringList[0][f] == stringList[1][s]) {
-                fstSndLCS.add(stringList[0][f]);
-                comCnt++;
-                f++;
-                s++;
-            }
-            s=0;
-            if(longest < comCnt){
-                longest = comCnt;
-                LCS = new char[longest];
-                for (int chI = 0; chI<longest; chI++) {
-                    LCS[chI] = fstSndLCS.get(chI);
+        int[][][] dp = new int[F + 1][S + 1][T + 1];
+
+        for (int i = 1; i <= F; i++) {
+            for (int j = 1; j <= S; j++) {
+                for (int k = 1; k <= T; k++) {
+                    if (stringList[0][i - 1] == stringList[1][j - 1] && stringList[0][i - 1] == stringList[2][k - 1]) {
+                        dp[i][j][k] = dp[i - 1][j - 1][k - 1] + 1;
+                        continue;
+                    }
+                    dp[i][j][k] = Math.max(Math.max(dp[i - 1][j][k], dp[i][j - 1][k]), dp[i][j][k - 1]);
+
                 }
             }
         }
 
-
+        System.out.println(dp[F][S][T]);
     }
 }


### PR DESCRIPTION
## 문제 :mag:

[BOJ/2606번](https://www.acmicpc.net/problem/2606) 바이러스

[BOJ/9663번](https://www.acmicpc.net/problem/9663) N-Queen

[BOJ/17829번](https://www.acmicpc.net/problem/17829) 222-풀링

[BOJ/20115번](https://www.acmicpc.net/problem/20115) 에너지 드링크

[BOJ/20365번](https://www.acmicpc.net/problem/20365) 블로그2

## 히스토리 :memo:

### BOJ/2606: 바이러스

> 1회 : [성공](https://github.com/SSAFY-79/algorithm-study/blob/minje/src/algorithm/minje/week3/boj/q2606/Main.java)

- bfs  with Node class

### BOJ/9663: N-Queen

> 1회 : [성공](https://github.com/SSAFY-79/algorithm-study/blob/minje/src/algorithm/minje/week3/boj/q9663/Main.java)

백트래킹 사용
- 같은 행에 놓을 수 없으니 1차원 배열에 퀸의 열 위치 담아주기
- 같은 열 or 대각선에 위치 시 다음 위치로

### BOJ/17829: 222-풀링

> 1회 : [성공](https://github.com/SSAFY-79/algorithm-study/blob/minje/src/algorithm/minje/week3/boj/q17829/Main.java)

- 2x2 배열에서 2번째로 큰 값을 찾고 해당 값으로 2x2 배열 전체를 초기화
- 직전 사이즈 * 2 (4x4) 배열 중에서 2번째로 큰 값을 찾는다. 그리고 그값으로 4x4 배열 전체 초기화
- 최종적으로 모든 배열 값이 한 값으로 초기화된다.

### BOJ/20115: 에너지 드링크

> 1회 : [성공](https://github.com/SSAFY-79/algorithm-study/blob/minje/src/algorithm/minje/week3/boj/q20115/Main.java)

- 제일 용량이 큰 드링크로 나머지 드링크를 모두 쏟아부으면 정답

### BOJ/20365: 블로그2

> 1회 : [성공](https://github.com/SSAFY-79/algorithm-study/blob/minje/src/algorithm/minje/week3/boj/q20365/Main.java)

- 그리디로 접근
<br>

## 하고 싶은 말(optional)

### BOJ/2606: 바이러스

Node class를 사용한 dfs로 풀었습니다.

### BOJ/9663: N-Queen

백트래킹 사용
- 같은 행에 놓을 수 없으니 1차원 배열에 퀸의 열 위치 담아주기
- 같은 열 or 대각선에 위치 시 다음 위치로

### BOJ/17829: 222-풀링

2x2 배열에서 2번째로 큰 값을 찾고 해당 값으로 2x2 배열 전체를 초기화
직전 사이즈 * 2 (4x4) 배열 중에서 2번째로 큰 값을 찾는다. 그리고 그값으로 4x4 배열 전체 초기화
최종적으로 모든 배열 값이 한 값으로 초기화된다.

### BOJ/20115: 에너지 드링크

제일 용량이 큰 드링크로 나머지 드링크를 모두 쏟아부으면 정답

### BOJ/20365: 블로그2

- 처음 칠한색(B)과 색이 다르다(R)면 paint count 1 증가
- (R)과 다른색(B)이 나올때까지 탐색중인 idx를 증가시킨다.
- 다시 처음 칠한색과 다른색이 나오면 paint count 1증가 ...
끝까지 반복